### PR TITLE
Support matcher configurations in url-select

### DIFF
--- a/url-select
+++ b/url-select
@@ -21,9 +21,9 @@
 #   q/Escape: Deactivate URL selection mode
 
 # Options:
-#   URxvt.urlLauncher:   Browser/command to open selected URL with
-#   URxvt.underlineURLs: If set to true, all URLs get underlined
-#   URvxt.urlButton:     Mouse button to click-open URLs (default: 2)
+#   URxvt.url-select.launcher:  Browser/command to open selected URL with
+#   URxvt.url-select.underline: If set to true, all URLs get underlined
+#   URvxt.url-select.button:    Mouse button to click-open URLs (default: 2)
 
 
 use strict;
@@ -32,16 +32,16 @@ sub on_start {
 	my ($self) = @_;
 
 	# read resource settings
-	if ($self->x_resource('urlLauncher')) {
-		@{$self->{browser}} = split /\s+/, $self->x_resource('urlLauncher');
+	if ($self->x_resource('urlLauncher') || $self->x_resource('url-select.launcher')) {
+		@{$self->{browser}} = split /\s+/, ($self->x_resource('urlLauncher') || $self->x_resource('url-select.launcher'));
 	} else {
 		@{$self->{browser}} = ('x-www-browser');
 	}
-	if ($self->x_resource('underlineURLs') eq 'true') {
+	if ($self->x_resource('underlineURLs') eq 'true' || $self->x_resource('url-select.underline') eq 'true') {
 		$self->enable(line_update => \&line_update);
 	}
-	if ($self->x_resource('urlButton') =~ /^\d+$/) {
-		$self->{button} = $self->x_resource('urlButton');
+	if (($self->x_resource('urlButton') || $self->x_resource('url-select.button')) =~ /^\d+$/) {
+		$self->{button} = $self->x_resource('urlButton') || $self->x_resource('url-select.button');
 	} elsif ($self->x_resource('matcher.button') =~ /^\d+$/) {
 		$self->{button} = $self->x_resource('matcher.button');
 	} else {


### PR DESCRIPTION
I use multiple patterns with the matcher plugin, and url-select wasn't selecting the urls properly.

```
URxvt*matcher.button:         1
URxvt*matcher.pattern.1:      \\b(mailto|http|https|ftp|file):/*[[:^space:]]+\\.[[:^space:]]*
URxvt*matcher.pattern.2:      \\bwww\\.[[:^space:]]+\\.[[:^space:]]*
```

These are the configs I have, with this pull request it can load those patterns if present, otherwise it uses the previously used regex.
