### PR TITLE
Fix typo from previous merge b5631d1

### DIFF
--- a/url-select
+++ b/url-select
@@ -58,10 +58,10 @@ sub on_start {
 			$current++;
 		}
 	} else {
-		@{$self->{pattern}} = (qr{
+		@{$self->{pattern}} = qr{(
 			(?:https?://|ftp://|news://|mailto:|file://|www\.)
 			[\w\-\@;\/?:&=%\$_.+!*\x27(),~#]+[\w\-\@;\/?&=%\$_+!*\x27()~]
-		}x);
+		)}x;
 	}
 
 	()


### PR DESCRIPTION
Typo from recent merge b5631d1d90dafcba41fc459a4ec9ccf4284d9743 stops underlining URLs working for those who don't have URxvt.matcher.pattern defined
