### PR TITLE
Fix pasting of non-ASCII characters

### DIFF
--- a/clipboard
+++ b/clipboard
@@ -64,6 +64,7 @@ sub paste {
 
 	my $str = `$self->{paste_cmd}`;
 	if ($? == 0) {
+		utf8::decode($str);
 		$self->tt_paste($str);
 	} else {
 		print STDERR "error running '$self->{paste_cmd}': $!\n";
@@ -77,6 +78,7 @@ sub paste_escaped {
 
 	my $str = `$self->{paste_cmd}`;
 	if ($? == 0) {
+		utf8::decode($str);
 		$str =~ s/([!#\$%&\*\(\) ='"\\\|\[\]`~,<>\?])/\\\1/g;
 		$self->tt_paste($str);
 	} else {


### PR DESCRIPTION
copy uses utf8::encode but paste/paste_escaped lack utf8::decode. 

This causes Unicode strings like "Ranma ½" to be pasted as if the
UTF-8 byte stream was decoded by another codec (latin1, I think).

This misbehaviour happens identically regardless of whether the copy originated in an external application or this very same urxvt script.
