### PR TITLE
keyboard-select: deactive for Ctr-C

### DIFF
--- a/keyboard-select
+++ b/keyboard-select
@@ -60,7 +60,8 @@ sub key_press {
 	my $key = chr($keysym);
 
 	if ($self->{search}) {
-		if ($keysym == 0xff1b) {
+		if ($keysym == 0xff1b ||
+			(lc($key) eq 'c' && $event->{state} & urxvt::ControlMask)) {
 			if ($self->{search_mode}) {
 				deactivate($self);
 			} else {
@@ -95,7 +96,8 @@ sub key_press {
 			status_area($self);
 		}
 	} elsif ($self->{move_to}) {
-		if ($keysym == 0xff1b) {
+		if ($keysym == 0xff1b ||
+			(lc($key) eq 'c' && $event->{state} & urxvt::ControlMask)) {
 			$self->{move_to} = 0;
 			status_area($self);
 		} elsif (length($char) > 0) {
@@ -105,7 +107,8 @@ sub key_press {
 			move_to($self, ';');
 			status_area($self);
 		}
-	} elsif ($keysym == 0xff1b || lc($key) eq 'q') {
+	} elsif ($keysym == 0xff1b || lc($key) eq 'q' ||
+			(lc($key) eq 'c' && $event->{state} & urxvt::ControlMask)) {
 		deactivate($self);
 	} elsif ($key eq 'y' || $keysym == 0xff0d) {
 		if ($self->{select}) {


### PR DESCRIPTION
Hi,

I attempted to handle the Ctr-C key_press events, for two reasons: 
1. In Vim I used Ctr-C to deactivate modes, and I thought keyboard-select could be more Vim like in this regard.
2. If you accidentally activated keyboard-select or accidentally left it activated (this happens to me quite often, that I already switch tab with tabbed, and can't see that keyboard-select is active on another tab)
So if you are unaware of keyboard-select being active and you want to send a signal to a process running in the foreground, you keep pressing Ctr-C but nothing happens. Now first keyboard-select deactivates, and then the second sends the SIGINT.

I hope this modification doesn't mess up or conflict with anything.
