### PR TITLE
compatibility with urxvt 9.21+

### DIFF
--- a/clipboard
+++ b/clipboard
@@ -86,6 +86,12 @@ sub paste_escaped {
 	()
 }
 
+sub on_action {
+    my ($self, $action) = @_;
+
+    on_user_command($self, "clipboard:" . $action);
+}
+
 sub on_user_command {
 	my ($self, $cmd) = @_;
 

--- a/keyboard-select
+++ b/keyboard-select
@@ -40,6 +40,13 @@ sub on_start{
 }
 
 
+sub on_action {
+    my ($self, $action) = @_;
+
+    on_user_command($self, "keyboard-select:" . $action);
+}
+
+
 sub on_user_command {
 	my ($self, $cmd) = @_;
 

--- a/url-select
+++ b/url-select
@@ -109,6 +109,12 @@ sub line_update {
 	()
 }
 
+sub on_action {
+    my ($self, $action) = @_;
+
+    on_user_command($self, "url-select:" . $action);
+}
+
 
 sub on_user_command {
 	my ($self, $cmd) = @_;


### PR DESCRIPTION
In 9.21 version new callback model was introduced, and in `on_user_command` was deprecated.

http://dist.schmorp.de/rxvt-unicode/Changes