### PR TITLE
keyboard-select and url-select: Add 'also-use-clipboard' option

### DIFF
--- a/deprecated/url-select
+++ b/deprecated/url-select
@@ -24,8 +24,12 @@
 #   URvxt.url-select.button:    Mouse button to click-open URLs (default: 2)
 #   URxvt.url-select.launcher:  Browser/command to open selected URL with
 #   URxvt.url-select.underline: If set to true, all URLs get underlined
+#   URxvt.url-select.also-use-clipboard: If set to true, copied URLs are also
+#                                        copied to CLIPBOARD
+
 
 use strict;
+use warnings;
 
 # The custom rendition bit to use for marking the cell as being underlined
 # by us so we can unset it again after a line has changed.
@@ -35,6 +39,9 @@ sub on_start {
 	my ($self) = @_;
 
 	# read resource settings
+	$self->{copy_cmd} = $self->x_resource('clipboard.copycmd') || 'xsel -ib';
+	$self->{also_use_clipboard} = $self->x_resource('url-select.also-use-clipboard') || 'false';
+
 	if ($self->x_resource('url-select.launcher')) {
 		@{$self->{browser}} = split /\s+/, $self->x_resource('url-select.launcher');
 	} else {
@@ -85,6 +92,26 @@ sub on_start {
 				[\w\-\@;\/?:&=%\$+*~]                # exclude some trailing characters (heuristic)
 			)+
 		}x;
+	}
+
+	()
+}
+
+
+sub copy {
+	my ($self) = @_;
+
+	if ($self->{also_use_clipboard} eq 'false') {
+            return;
+	}
+
+	if (open(CLIPBOARD, "| $self->{copy_cmd}")) {
+		my $sel = $self->selection();
+		utf8::encode($sel);
+		print CLIPBOARD $sel;
+		close(CLIPBOARD);
+	} else {
+		print STDERR "error running '$self->{copy_cmd}': $!\n";
 	}
 
 	()
@@ -162,6 +189,7 @@ sub key_press {
 		$self->selection_beg(${$found}[0], ${$found}[1]);
 		$self->selection_end(${$found}[2], ${$found}[3]);
 		$self->selection_make($event->{time});
+		copy($self);
 		$self->selection_beg(1, 0);
 		$self->selection_end(1, 0);
 		deactivate($self);
@@ -248,6 +276,7 @@ sub select_next {
 			$self->selection_beg(${$found}[0], ${$found}[1]);
 			$self->selection_end(${$found}[2], ${$found}[3]);
 			$self->selection_make($event->{time});
+			copy($self);
 			$self->selection_beg(1, 0);
 			$self->selection_end(1, 0);
 		}
@@ -279,6 +308,7 @@ sub select_next {
 					$self->selection_beg(${$found}[0], ${$found}[1]);
 					$self->selection_end(${$found}[2], ${$found}[3]);
 					$self->selection_make($event->{time});
+					copy($self);
 					$self->selection_beg(1, 0);
 					$self->selection_end(1, 0);
 				}

--- a/keyboard-select
+++ b/keyboard-select
@@ -24,11 +24,19 @@
 #   Y:          Copy selected lines to primary buffer or cursor line and quit
 #   q/Escape:   Quit keyboard selection mode
 
+# Options:
+#   URxvt.keyboard-select.also-use-clipboard: If set to true, copied content
+#                                             is also copied to CLIPBOARD
+
 
 use strict;
+use warnings;
 
 sub on_start{
 	my ($self) = @_;
+
+	$self->{copy_cmd} = $self->x_resource('clipboard.copycmd') || 'xsel -ib';
+	$self->{also_use_clipboard} = $self->x_resource('keyboard-select.also-use-clipboard') || 'false';
 
 	$self->{patterns}{'w'} = qr/\w[^\w\s]|\W\w|\s\S/;
 	$self->{patterns}{'W'} = qr/\s\S/;
@@ -36,6 +44,25 @@ sub on_start{
 	$self->{patterns}{'B'} = qr/.*\s\S/;
 	$self->{patterns}{'e'} = qr/[^\w\s](?=\w)|\w(?=\W)|\S(?=\s|$)/;
 	$self->{patterns}{'E'} = qr/\S(?=\s|$)/;
+
+	()
+}
+
+sub copy {
+	my ($self) = @_;
+
+	if ($self->{also_use_clipboard} eq 'false') {
+            return;
+	}
+
+	if (open(CLIPBOARD, "| $self->{copy_cmd}")) {
+		my $sel = $self->selection();
+		utf8::encode($sel);
+		print CLIPBOARD $sel;
+		close(CLIPBOARD);
+	} else {
+		print STDERR "error running '$self->{copy_cmd}': $!\n";
+	}
 
 	()
 }
@@ -141,6 +168,7 @@ sub key_press {
 			$self->selection_beg($br, $bc);
 			$self->selection_end($er, $ec);
 			$self->selection_make($event->{time}, $self->{select} eq 'b');
+			copy($self);
 			if (lc($key) eq 'y') {
 				$self->selection_beg(1, 0);
 				$self->selection_end(1, 0);


### PR DESCRIPTION
Hi,

This PR adds the ability to copy both in PRIMARY and in CLIPBOARD buffers from `keyboard-select` and from `url-select` (EDIT).
This should solve the following (duplicated) issues: #39, #52, #53, #57, #55, #65 and #81.

I rely on the option explained here: https://github.com/muennich/urxvt-perls/blob/master/deprecated/clipboard#L21
However, I do not rely on the code of `clipboard`. I thought that using the same option could be a good idea.

The function `copy` is just a modified version of this one: https://github.com/muennich/urxvt-perls/blob/master/deprecated/clipboard#L47

Best regards,
hasB4K